### PR TITLE
Add option to replace symlink layers with cached layers

### DIFF
--- a/cmd/commands/env.go
+++ b/cmd/commands/env.go
@@ -47,6 +47,7 @@ func explorerEnvironment(clictx *cli.Context) (context.Context, explorers.Contai
 	dockerroot := clictx.GlobalString("docker-root")
 	metadatafile := clictx.GlobalString("metadata-file")
 	snapshotfile := clictx.GlobalString("snapshot-metadata-file")
+	layercache := clictx.GlobalString("layer-cache")
 
 	// Read support container data if provided using global switch.
 	var sc *explorers.SupportContainer
@@ -119,7 +120,10 @@ func explorerEnvironment(clictx *cli.Context) (context.Context, explorers.Contai
 		"snapshotfile":   snapshotfile,
 	}).Debug("containerd container environment")
 
-	cde, err := containerd.NewExplorer(imageroot, containerdroot, metadatafile, snapshotfile, sc)
+	if !clictx.GlobalBool("use-layer-cache") {
+		layercache = ""
+	}
+	cde, err := containerd.NewExplorer(imageroot, containerdroot, metadatafile, snapshotfile, layercache, sc)
 	if err != nil {
 		return ctx, nil, func() { cancel() }, err
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,6 +84,15 @@ func main() {
 			Name:  "snapshot-metadata-file, s",
 			Usage: "specify the path to containerd snapshot metadata file i.e. metadata.db.",
 		},
+		cli.BoolFlag{
+			Name:  "use-layer-cache",
+			Usage: "attempt to use cached layers where layers are symlinks",
+		},
+		cli.StringFlag{
+			Name:  "layer-cache",
+			Usage: "cached layer folder within the snapshot root",
+			Value: "layers",
+		},
 		cli.StringFlag{
 			Name:  "namespace, n",
 			Usage: "specify container namespace",


### PR DESCRIPTION
When mounting containers, attempt to replace symlink layers with cached layers maintained by the containerd snapshotter