### PR TITLE
Fixed export without filter param.

### DIFF
--- a/cmd/commands/export.go
+++ b/cmd/commands/export.go
@@ -30,8 +30,8 @@ import (
 
 var ExportCommand = cli.Command{
 	Name:        "export",
-	Usage:       "export a container",
-	Description: "export a container",
+	Usage:       "export a container as image or archive",
+	Description: "export a container as image or archive",
 	ArgsUsage:   "ID OUTPUTDIR",
 	Flags: []cli.Flag{
 		cli.BoolFlag{

--- a/explorers/containerd/export.go
+++ b/explorers/containerd/export.go
@@ -49,7 +49,7 @@ func (e *explorer) ExportContainer(ctx context.Context, containerID string, outp
 				"namespace": containerNamespace,
 				"error": err,
 			}).Warnf("error listing containers in namespace")
-			
+
 			continue
 		}
 
@@ -168,6 +168,11 @@ func (e *explorer) ExportAllContainers(ctx context.Context, outputDir string, ex
 			continue
 		}
 
+		log.WithFields(log.Fields{
+			"namespace": containerNamespace,
+			"container_count": len(containers),
+		}).Debug("containerd containers in namespace")
+
 		for _, container := range containers {
 			log.WithFields(log.Fields{
 				"containerID": container.ID,
@@ -193,7 +198,7 @@ func (e *explorer) ExportAllContainers(ctx context.Context, outputDir string, ex
 					"namespace": container.Namespace,
 					"containerType": container.ContainerType,
 				}).Debug("ignoring containerd container for export")
-				
+
 				err := e.ExportContainer(ctx, container.ID, outputDir, exportOption)
 				if err != nil {
 					log.WithFields(log.Fields{

--- a/explorers/docker/export.go
+++ b/explorers/docker/export.go
@@ -49,7 +49,7 @@ func (e *explorer) ExportContainer(ctx context.Context, containerID string, outp
 				"namespace": containerNamespace,
 				"error": err,
 			}).Warnf("error listing containers in namespace")
-			
+
 			continue
 		}
 
@@ -168,6 +168,10 @@ func (e *explorer) ExportAllContainers(ctx context.Context, outputDir string, ex
 
 			continue
 		}
+		log.WithFields(log.Fields{
+			"namespace": containerNamespace,
+			"container_count": len(containers),
+		}).Debug("Docker containers in namespace")
 
 		for _, container := range containers {
 			log.WithFields(log.Fields{

--- a/utils/container.go
+++ b/utils/container.go
@@ -37,6 +37,10 @@ func IgnoreContainer(container explorers.Container, filter map[string]string) bo
 }
 
 func IncludeContainer(container explorers.Container, filter map[string]string) bool {
+	if filter == nil {
+		return true
+	}
+
 	include := false
 
 	for k, v := range filter {


### PR DESCRIPTION
**Issue** `ce -i /mnt/disk export-all /tmp/export_dir --image` failed to export all containers as image.

This was fixed by correctly checking  `--filter key=value` value.