### PR TITLE
Add handling for unspecified snapshotter

### DIFF
--- a/explorers/containerd/containerd.go
+++ b/explorers/containerd/containerd.go
@@ -449,6 +449,102 @@ func (e *explorer) InfoContainer(ctx context.Context, containerid string, spec b
 	return nil, nil
 }
 
+// resolveSnapshotter checks the snapshotter in meta.db.
+// If not found, falls back to "overlayfs".
+func (e *explorer) resolveSnapshotter(ctx context.Context, container *containers.Container) {
+	if container.Snapshotter != "" && container.SnapshotKey != "" {
+		return
+	}
+
+	namespace, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		log.Warnf("failed to get namespace from context when resolving snapshotter: %v", err)
+		if container.Snapshotter == "" {
+			container.Snapshotter = "overlayfs" // default fallback
+		}
+		if container.SnapshotKey == "" {
+			container.SnapshotKey = container.ID
+		}
+		return
+	}
+
+	var foundSnapshotter string
+	var foundSnapshotKey string
+
+	_ = e.mdb.View(func(tx *bolt.Tx) error {
+		bkt := getSnapshottersBucket(tx, namespace)
+		if bkt == nil {
+			return nil
+		}
+
+		searchSnapshotter := func(snapshotterName string) error {
+			ssbkt := bkt.Bucket([]byte(snapshotterName))
+			if ssbkt == nil {
+				return nil
+			}
+
+			if container.SnapshotKey != "" {
+				if skBkt := ssbkt.Bucket([]byte(container.SnapshotKey)); skBkt != nil {
+					foundSnapshotter = snapshotterName
+					foundSnapshotKey = container.SnapshotKey
+					return fmt.Errorf("found")
+				}
+			} else {
+				// Try container.ID as the snapshot key
+				if skBkt := ssbkt.Bucket([]byte(container.ID)); skBkt != nil {
+					foundSnapshotter = snapshotterName
+					foundSnapshotKey = container.ID
+					return fmt.Errorf("found")
+				}
+
+				// Search for a snapshot key containing container.ID
+				var matchedKey string
+				_ = ssbkt.ForEach(func(k, v []byte) error {
+					keyStr := string(k)
+					if strings.Contains(keyStr, container.ID) {
+						matchedKey = keyStr
+						return fmt.Errorf("found_match")
+					}
+					return nil
+				})
+				if matchedKey != "" {
+					foundSnapshotter = snapshotterName
+					foundSnapshotKey = matchedKey
+					return fmt.Errorf("found")
+				}
+			}
+			return nil
+		}
+
+		if container.Snapshotter != "" {
+			return searchSnapshotter(container.Snapshotter)
+		}
+
+		// If container.Snapshotter is empty, search all snapshotters
+		_ = bkt.ForEach(func(k, v []byte) error {
+			if err := searchSnapshotter(string(k)); err != nil {
+				return err
+			}
+			return nil
+		})
+		return nil
+	})
+
+	if foundSnapshotter != "" {
+		container.Snapshotter = foundSnapshotter
+		container.SnapshotKey = foundSnapshotKey
+		log.Infof("resolved empty snapshotter/key for container %s to snapshotter=%s, key=%s", container.ID, foundSnapshotter, foundSnapshotKey)
+	} else {
+		if container.Snapshotter == "" {
+			container.Snapshotter = "overlayfs" // default fallback
+		}
+		if container.SnapshotKey == "" {
+			container.SnapshotKey = container.ID // default fallback to container ID
+		}
+		log.Warnf("could not resolve snapshotter/key in meta.db for container %s, falling back to snapshotter=%s, key=%s", container.ID, container.Snapshotter, container.SnapshotKey)
+	}
+}
+
 // MountContainer mounts a container to the specified path
 func (e *explorer) MountContainer(ctx context.Context, containerid string, mountpoint string) error {
 	store := metadata.NewContainerStore(metadata.NewDB(e.mdb, nil, nil))
@@ -457,6 +553,8 @@ func (e *explorer) MountContainer(ctx context.Context, containerid string, mount
 	if err != nil {
 		return fmt.Errorf("failed getting container information %v", err)
 	}
+
+	e.resolveSnapshotter(ctx, &container)
 
 	// Snapshot database metadata.db access
 	opts := bolt.Options{
@@ -728,6 +826,7 @@ func (e *explorer) ContainerDrift(ctx context.Context, filter string, skipsuppor
 		if err != nil {
 			return nil, fmt.Errorf("failed getting container information %v", err)
 		}
+		e.resolveSnapshotter(ctx, &container)
 		// Snapshot database metadata.db access
 		opts := bolt.Options{
 			ReadOnly: true,

--- a/explorers/containerd/containerd.go
+++ b/explorers/containerd/containerd.go
@@ -451,27 +451,26 @@ func (e *explorer) InfoContainer(ctx context.Context, containerid string, spec b
 
 // resolveSnapshotter checks the snapshotter in meta.db.
 // If not found, falls back to "overlayfs".
-func (e *explorer) resolveSnapshotter(ctx context.Context, container *containers.Container) {
+func (e *explorer) resolveSnapshotter(ctx context.Context, container *containers.Container) error {
 	if container.Snapshotter != "" && container.SnapshotKey != "" {
-		return
+		return nil
 	}
 
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
-		log.Warnf("failed to get namespace from context when resolving snapshotter: %v", err)
 		if container.Snapshotter == "" {
 			container.Snapshotter = "overlayfs" // default fallback
 		}
 		if container.SnapshotKey == "" {
 			container.SnapshotKey = container.ID
 		}
-		return
+		return fmt.Errorf("failed to get namespace from context when resolving snapshotter: %w", err)
 	}
 
 	var foundSnapshotter string
 	var foundSnapshotKey string
 
-	_ = e.mdb.View(func(tx *bolt.Tx) error {
+	dbErr := e.mdb.View(func(tx *bolt.Tx) error {
 		bkt := getSnapshottersBucket(tx, namespace)
 		if bkt == nil {
 			return nil
@@ -530,6 +529,10 @@ func (e *explorer) resolveSnapshotter(ctx context.Context, container *containers
 		return nil
 	})
 
+	if dbErr != nil && dbErr.Error() != "found" {
+		return fmt.Errorf("failed to view database: %w", dbErr)
+	}
+
 	if foundSnapshotter != "" {
 		container.Snapshotter = foundSnapshotter
 		container.SnapshotKey = foundSnapshotKey
@@ -543,6 +546,7 @@ func (e *explorer) resolveSnapshotter(ctx context.Context, container *containers
 		}
 		log.Warnf("could not resolve snapshotter/key in meta.db for container %s, falling back to snapshotter=%s, key=%s", container.ID, container.Snapshotter, container.SnapshotKey)
 	}
+	return nil
 }
 
 // MountContainer mounts a container to the specified path
@@ -554,7 +558,9 @@ func (e *explorer) MountContainer(ctx context.Context, containerid string, mount
 		return fmt.Errorf("failed getting container information %v", err)
 	}
 
-	e.resolveSnapshotter(ctx, &container)
+	if err := e.resolveSnapshotter(ctx, &container); err != nil {
+		return fmt.Errorf("failed to resolve snapshotter: %w", err)
+	}
 
 	// Snapshot database metadata.db access
 	opts := bolt.Options{
@@ -826,7 +832,9 @@ func (e *explorer) ContainerDrift(ctx context.Context, filter string, skipsuppor
 		if err != nil {
 			return nil, fmt.Errorf("failed getting container information %v", err)
 		}
-		e.resolveSnapshotter(ctx, &container)
+		if err := e.resolveSnapshotter(ctx, &container); err != nil {
+			return nil, fmt.Errorf("failed to resolve snapshotter: %w", err)
+		}
 		// Snapshot database metadata.db access
 		opts := bolt.Options{
 			ReadOnly: true,

--- a/explorers/containerd/snapshot.go
+++ b/explorers/containerd/snapshot.go
@@ -157,7 +157,7 @@ func (s *snapshotStore) NativePath(ctx context.Context, container containers.Con
 
 	snapshotkeys, err := s.SnapshotKeys(ctx, container)
 	if err != nil {
-		return "", fmt.Errorf("could not get snapshot keys for container ", container.ID)
+		return "", fmt.Errorf("could not get snapshot keys for container %s", container.ID)
 	}
 
 	var (
@@ -192,7 +192,7 @@ func (s *snapshotStore) OverlayPath(ctx context.Context, container containers.Co
 
 	snapshotkeys, err := s.SnapshotKeys(ctx, container)
 	if err != nil {
-		return "", "", "", fmt.Errorf("could not get snapshot keys for container ", container.ID)
+		return "", "", "", fmt.Errorf("could not get snapshot keys for container %s", container.ID)
 	}
 
 	var (


### PR DESCRIPTION
Adding logic to fall back to overlayfs if no snapshotter is specified in meta.db